### PR TITLE
feat(identity-registry): update contract logic and public API

### DIFF
--- a/contracts/identity-registry-contract/src/lib.rs
+++ b/contracts/identity-registry-contract/src/lib.rs
@@ -26,7 +26,12 @@ impl IdentityRegistryContract {
     pub fn batch_add_experts(env: Env, experts: Vec<Address>) -> Result<(), RegistryError> {
         contract::batch_add_experts(env, experts)
     }
-    
+
+    /// Batch ban experts and revoke their verification status (Admin only)
+    pub fn batch_ban_experts(env: Env, experts: Vec<Address>) -> Result<(), RegistryError> {
+        contract::batch_ban_experts(env, experts)
+    }
+
     /// Add an expert to the whitelist (Admin only)
     pub fn add_expert(env: Env, expert: Address) -> Result<(), RegistryError> {
         contract::verify_expert(&env, &expert)


### PR DESCRIPTION

# 🧠 SkillSphere Pull Request 🌐

Mark with an `x` all the checkboxes that apply (like `[x]`)

- [x] Closes #5
- [ ] Added tests (if necessary)
- [ ] Ran `cargo test` (All tests passed)
- [x] Evidence attached (Screenshots, Logs, or Transaction Hashes)
- [x] Commented the code

---

## 📌 Type of Change

- [ ] 📚 Documentation (updates to README, docs, or comments)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ Enhancement (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🏗️ Refactor (code improvement/cleanup without logical changes)

---

## 📝 Changes Description

Implemented **batch banning functionality** for the **Identity Registry contract**, allowing admins to ban multiple experts in a single transaction.

### 🔑 Changes Made

#### 1️⃣ Batch Ban Logic (`src/contract.rs`)
- Added `batch_ban_experts` function (lines 39–58)
- Accepts a vector of expert addresses to ban
- Validates a **maximum batch size of 20** (gas safety)
- Enforces **admin-only authorization** via `admin.require_auth()`
- Iterates through each expert:
  - Ensures the expert is not already banned
  - Updates status to `ExpertStatus::Banned`
  - Emits an `ExpertStatusChanged` event per expert

#### 2️⃣ Public API Exposure (`src/lib.rs`)
- Exposed `batch_ban_experts` as part of the contract’s public interface
- Follows the same pattern as the existing `batch_add_experts` function

---

### ⚙️ Technical Details

- **Gas Optimization**
  - Single admin authentication for the entire batch
- **Safety Checks**
  - Fails if batch size exceeds 20 (`RegistryError::ExpertVecMax`)
  - Fails atomically if any expert is already banned (`RegistryError::AlreadyBanned`)
- **Event Emission**
  - Emits `ExpertStatusChanged` for each expert with:
    - Expert address
    - Previous status
    - New status (`Banned`)
    - Admin address

---

### 📊 Impact

- **Storage**: No new storage keys introduced (reuses existing expert records)
- **Gas**: More efficient than repeated `ban_expert` calls
- **Frontend**: Events enable real-time UI updates for each banned expert

---

## 📸 Evidence

### ✅ Build Output

- Build: **Successful**
- Target: `wasm32-unknown-unknown`
- Wasm Hash:  
  `10c7ceb88c70aad633f693e6fa18dfa9b015d8ba6d509220e90bbdcdefe59363`

### 📦 Exported Functions
- `add_expert`
- `ban_expert`
- `batch_add_experts`
- `batch_ban_experts` ← **NEW**
- `get_status`
- `init`
- `is_verified`

---

### 🧪 Function Implementation

**Location:** `contracts/identity-registry-contract/src/contract.rs:39–58`

```rust
/// Batch ban experts by setting their status to Banned (Admin only)
pub fn batch_ban_experts(env: Env, experts: Vec<Address>) -> Result<(), RegistryError> {
    if experts.len() > 20 {
        return Err(RegistryError::ExpertVecMax);
    }

    let admin = storage::get_admin(&env).ok_or(RegistryError::NotInitialized)?;
    admin.require_auth();

    for expert in experts {
        let status = storage::get_expert_status(&env, &expert);
        if status == ExpertStatus::Banned {
            return Err(RegistryError::AlreadyBanned);
        }

        storage::set_expert_record(&env, &expert, ExpertStatus::Banned);
        events::emit_status_change(
            &env,
            expert,
            status,
            ExpertStatus::Banned,
            admin.clone(),
        );
    }

    Ok(())
}
````

---

## 🌌 Comments

### ✅ Acceptance Criteria (Issue #5)

* Admin can ban **10+ experts** in a single transaction (up to 20)
* All targeted experts immediately return `ExpertStatus::Banned`
* Events are emitted for every banned expert (frontend sync)

### 📝 Implementation Notes

* Mirrors the `batch_add_experts` pattern for consistency
* The 20-expert limit aligns with Soroban gas constraints
* Transaction is **fully atomic**: if one expert fails, no state changes are applied

### 🔍 Suggested Tests (Future Work)

* Batch banning exactly 20 experts
* Failure when batch size exceeds 20
* Failure when any expert is already banned
* Event emission validation
* Unauthorized access attempt

### 👀 Reviewer Checklist

* [ ] Validate batch size enforcement
* [ ] Confirm atomic failure behavior
* [ ] Verify admin-only access control
* [ ] Check event emission per expert
* [ ] Review gas usage for large batches

---

Thank you for contributing to **SkillSphere**! 🌍
Together, we’re building a **trustless, peer-to-peer consulting economy** on Stellar. 🚀




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Batch expert banning capability with a maximum of 20 experts per operation, enabling efficient bulk administrative management.
  * Validation to prevent duplicate bans and maintain registry data consistency and integrity.

* **Improvements**
  * Mandatory admin authentication required for all expert status modification operations.
  * Enhanced event tracking system with historical status references for complete audit trails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->