### PR TITLE
feat(payment-vault): support multiple whitelisted payment tokens

### DIFF
--- a/contracts/payment-vault-contract/src/contract.rs
+++ b/contracts/payment-vault-contract/src/contract.rs
@@ -18,7 +18,8 @@ pub fn initialize_vault(
 
     // 2. Save State
     storage::set_admin(env, admin);
-    storage::set_token(env, token);
+    // Seed the first allowed payment token so the vault is immediately usable
+    storage::add_allowed_token(env, token);
     storage::set_oracle(env, oracle);
     storage::set_registry_address(env, registry);
 
@@ -41,6 +42,24 @@ pub fn unpause(env: &Env) -> Result<(), VaultError> {
     Ok(())
 }
 
+/// Whitelist a new payment token (Admin-only).
+/// Once added, users may book sessions using this token.
+pub fn add_payment_token(env: &Env, token: &Address) -> Result<(), VaultError> {
+    let admin = storage::get_admin(env).ok_or(VaultError::NotInitialized)?;
+    admin.require_auth();
+    storage::add_allowed_token(env, token);
+    Ok(())
+}
+
+/// Remove a previously whitelisted payment token (Admin-only).
+/// Existing bookings using this token are unaffected; only new bookings are blocked.
+pub fn remove_payment_token(env: &Env, token: &Address) -> Result<(), VaultError> {
+    let admin = storage::get_admin(env).ok_or(VaultError::NotInitialized)?;
+    admin.require_auth();
+    storage::remove_allowed_token(env, token);
+    Ok(())
+}
+
 pub fn set_my_rate(env: &Env, expert: &Address, rate_per_second: i128) -> Result<(), VaultError> {
     expert.require_auth();
 
@@ -59,6 +78,7 @@ pub fn book_session(
     user: &Address,
     expert: &Address,
     max_duration: u64,
+    payment_token: &Address,
 ) -> Result<u64, VaultError> {
     if storage::is_paused(env) {
         return Err(VaultError::ContractPaused);
@@ -66,6 +86,11 @@ pub fn book_session(
 
     // Require authorization from the user creating the booking
     user.require_auth();
+
+    // Verify the requested payment token is whitelisted
+    if !storage::is_token_allowed(env, payment_token) {
+        return Err(VaultError::TokenNotAllowed);
+    }
 
     // Verify expert is verified via Identity Registry cross-contract call
     let registry_address = storage::get_registry_address(env).ok_or(VaultError::NotInitialized)?;
@@ -99,11 +124,8 @@ pub fn book_session(
         return Err(VaultError::InvalidAmount);
     }
 
-    // Get the token contract
-    let token_address = storage::get_token(env);
-    let token_client = token::Client::new(env, &token_address);
-
-    // Transfer tokens from user to this contract
+    // Transfer tokens from user to this contract using the chosen payment token
+    let token_client = token::Client::new(env, payment_token);
     let contract_address = env.current_contract_address();
     token_client.transfer(user, &contract_address, &total_deposit);
 
@@ -113,6 +135,7 @@ pub fn book_session(
         id: booking_id,
         user: user.clone(),
         expert: expert.clone(),
+        token_address: payment_token.clone(),
         rate_per_second,
         max_duration,
         total_deposit,
@@ -173,9 +196,8 @@ pub fn top_up_session(
         return Err(VaultError::InvalidAmount);
     }
 
-    // Get the token contract
-    let token_address = storage::get_token(env);
-    let token_client = token::Client::new(env, &token_address);
+    // Get the token contract using the token stored in the booking
+    let token_client = token::Client::new(env, &booking.token_address);
 
     // Transfer extra tokens from user to this contract
     let contract_address = env.current_contract_address();
@@ -235,9 +257,8 @@ pub fn finalize_session(
         return Err(VaultError::InvalidAmount);
     }
 
-    // 5. Get token contract
-    let token_address = storage::get_token(env);
-    let token_client = token::Client::new(env, &token_address);
+    // 5. Get token contract from the booking record
+    let token_client = token::Client::new(env, &booking.token_address);
     let contract_address = env.current_contract_address();
 
     // 6. Execute transfers
@@ -291,8 +312,7 @@ pub fn reclaim_stale_session(env: &Env, user: &Address, booking_id: u64) -> Resu
     }
 
     // 6. Transfer total_deposit back to user
-    let token_address = storage::get_token(env);
-    let token_client = token::Client::new(env, &token_address);
+    let token_client = token::Client::new(env, &booking.token_address);
     let contract_address = env.current_contract_address();
     token_client.transfer(&contract_address, &booking.user, &booking.total_deposit);
 
@@ -351,8 +371,7 @@ pub fn cancel_booking(env: &Env, user: &Address, booking_id: u64) -> Result<(), 
         return Err(VaultError::SessionAlreadyStarted);
     }
 
-    let token_address = storage::get_token(env);
-    let token_client = token::Client::new(env, &token_address);
+    let token_client = token::Client::new(env, &booking.token_address);
     let contract_address = env.current_contract_address();
     token_client.transfer(&contract_address, &booking.user, &booking.total_deposit);
 
@@ -411,8 +430,7 @@ pub fn reject_session(env: &Env, expert: &Address, booking_id: u64) -> Result<()
     }
 
     // 5. Transfer total_deposit back to user
-    let token_address = storage::get_token(env);
-    let token_client = token::Client::new(env, &token_address);
+    let token_client = token::Client::new(env, &booking.token_address);
     let contract_address = env.current_contract_address();
     token_client.transfer(&contract_address, &booking.user, &booking.total_deposit);
 
@@ -462,9 +480,8 @@ pub fn resolve_dispute(
         return Err(VaultError::InvalidAmount);
     }
 
-    // 5. Get token contract
-    let token_address = storage::get_token(env);
-    let token_client = token::Client::new(env, &token_address);
+    // 5. Get token contract from the booking record
+    let token_client = token::Client::new(env, &booking.token_address);
     let contract_address = env.current_contract_address();
 
     // 6. Execute transfers
@@ -522,8 +539,7 @@ pub fn recover_disputed_remainder(env: &Env, booking_id: u64) -> Result<i128, Va
         return Err(VaultError::InvalidAmount);
     }
 
-    let token_address = storage::get_token(env);
-    let token_client = token::Client::new(env, &token_address);
+    let token_client = token::Client::new(env, &booking.token_address);
     let contract_address = env.current_contract_address();
 
     if remainder > 0 {

--- a/contracts/payment-vault-contract/src/error.rs
+++ b/contracts/payment-vault-contract/src/error.rs
@@ -18,4 +18,5 @@ pub enum VaultError {
     Overflow = 12,
     BookingNotDisputed = 13,
     RemainderAlreadyRecovered = 14,
+    TokenNotAllowed = 15,
 }

--- a/contracts/payment-vault-contract/src/lib.rs
+++ b/contracts/payment-vault-contract/src/lib.rs
@@ -39,6 +39,18 @@ impl PaymentVaultContract {
         contract::unpause(&env)
     }
 
+    /// Whitelist a payment token so users can book sessions with it (Admin-only).
+    /// The token passed to `init` is automatically whitelisted at initialization.
+    pub fn add_payment_token(env: Env, token: Address) -> Result<(), VaultError> {
+        contract::add_payment_token(&env, &token)
+    }
+
+    /// Remove a previously whitelisted payment token (Admin-only).
+    /// Existing bookings using this token are unaffected; only new bookings are blocked.
+    pub fn remove_payment_token(env: Env, token: Address) -> Result<(), VaultError> {
+        contract::remove_payment_token(&env, &token)
+    }
+
     /// Transfer admin rights to a new address (Admin-only)
     /// Old admin instantly loses all privileges
     pub fn transfer_admin(env: Env, new_admin: Address) -> Result<(), VaultError> {
@@ -61,14 +73,17 @@ impl PaymentVaultContract {
     /// Book a session with an expert.
     /// User deposits tokens upfront based on rate_per_second * max_duration.
     /// Both `rate_per_second` and the resulting `total_deposit` are denominated in
-    /// atomic units of the configured payment token to correctly handle any token precision.
+    /// atomic units of the chosen `payment_token` to correctly handle any token precision.
+    /// `payment_token` must be on the admin-maintained allowlist; booking fails with
+    /// `TokenNotAllowed` otherwise.
     pub fn book_session(
         env: Env,
         user: Address,
         expert: Address,
         max_duration: u64,
+        payment_token: Address,
     ) -> Result<u64, VaultError> {
-        contract::book_session(&env, &user, &expert, max_duration)
+        contract::book_session(&env, &user, &expert, max_duration, &payment_token)
     }
 
     /// Add more time to a live (or pending) session without disconnecting.

--- a/contracts/payment-vault-contract/src/storage.rs
+++ b/contracts/payment-vault-contract/src/storage.rs
@@ -5,14 +5,14 @@ use soroban_sdk::{contracttype, Address, Env};
 #[derive(Clone)]
 pub enum DataKey {
     Admin,
-    Token,
     Oracle,
-    RegistryAddress,        
-    Booking(u64),            // Booking ID -> BookingRecord
-    BookingCounter,          // Counter for generating unique booking IDs
-    UserBookings(Address),   // User Address -> Vec<u64> of booking IDs
-    ExpertBookings(Address), // Expert Address -> Vec<u64> of booking IDs
-    IsPaused,                // Circuit breaker flag
+    RegistryAddress,
+    Booking(u64),              // Booking ID -> BookingRecord
+    BookingCounter,            // Counter for generating unique booking IDs
+    UserBookings(Address),     // User Address -> Vec<u64> of booking IDs
+    ExpertBookings(Address),   // Expert Address -> Vec<u64> of booking IDs
+    IsPaused,                  // Circuit breaker flag
+    AllowedToken(Address),     // Address -> bool; true = whitelisted payment token
     // ── Indexed User Booking List ──────────────────────────────────────────
     // Replaces the old Vec<u64> approach with O(1) per-write composite keys.
     UserBooking(Address, u32), // (user, index) -> booking_id
@@ -20,7 +20,7 @@ pub enum DataKey {
     // ── Indexed Expert Booking List ────────────────────────────────────────
     ExpertBooking(Address, u32), // (expert, index) -> booking_id
     ExpertBookingCount(Address), // expert -> total count (u32)
-    ExpertRate(Address),     // Expert Address -> rate per second (i128)
+    ExpertRate(Address),       // Expert Address -> rate per second (i128)
 }
 
 // --- Admin ---
@@ -37,13 +37,29 @@ pub fn get_admin(env: &Env) -> Option<Address> {
     env.storage().instance().get(&DataKey::Admin)
 }
 
-// --- Token (USDC/XLM) ---
-pub fn set_token(env: &Env, token: &Address) {
-    env.storage().instance().set(&DataKey::Token, token);
+// --- Allowed Payment Tokens ---
+
+/// Whitelist a token address so users can book sessions with it.
+pub fn add_allowed_token(env: &Env, token: &Address) {
+    env.storage()
+        .instance()
+        .set(&DataKey::AllowedToken(token.clone()), &true);
 }
 
-pub fn get_token(env: &Env) -> Address {
-    env.storage().instance().get(&DataKey::Token).unwrap()
+/// Remove a token from the whitelist.
+/// Does nothing if the token was not previously allowed.
+pub fn remove_allowed_token(env: &Env, token: &Address) {
+    env.storage()
+        .instance()
+        .remove(&DataKey::AllowedToken(token.clone()));
+}
+
+/// Returns true if the given token is on the whitelist.
+pub fn is_token_allowed(env: &Env, token: &Address) -> bool {
+    env.storage()
+        .instance()
+        .get::<DataKey, bool>(&DataKey::AllowedToken(token.clone()))
+        .unwrap_or(false)
 }
 
 // --- Oracle (Backend) ---

--- a/contracts/payment-vault-contract/src/test.rs
+++ b/contracts/payment-vault-contract/src/test.rs
@@ -88,7 +88,7 @@ fn test_partial_duration_scenario() {
     let max_duration = 100_u64;
     let booking_id = {
         client.set_my_rate(&expert, &rate_per_second);
-        client.book_session(&user, &expert, &max_duration)
+        client.book_session(&user, &expert, &max_duration, &token.address)
     };
 
     assert_eq!(token.balance(&user), 9_000);
@@ -124,7 +124,7 @@ fn test_full_duration_no_refund() {
     let max_duration = 100_u64;
     let booking_id = {
         client.set_my_rate(&expert, &rate_per_second);
-        client.book_session(&user, &expert, &max_duration)
+        client.book_session(&user, &expert, &max_duration, &token.address)
     };
 
     let actual_duration = 100_u64;
@@ -157,7 +157,7 @@ fn test_double_finalization_protection() {
     let max_duration = 100_u64;
     let booking_id = {
         client.set_my_rate(&expert, &rate_per_second);
-        client.book_session(&user, &expert, &max_duration)
+        client.book_session(&user, &expert, &max_duration, &token.address)
     };
 
     let actual_duration = 50_u64;
@@ -190,7 +190,7 @@ fn test_oracle_authorization_enforcement() {
     let max_duration = 100_u64;
     let booking_id = {
         client.set_my_rate(&expert, &rate_per_second);
-        client.book_session(&user, &expert, &max_duration)
+        client.book_session(&user, &expert, &max_duration, &token.address)
     };
 
     env.set_auths(&[]);
@@ -226,7 +226,7 @@ fn test_zero_duration_finalization() {
     let max_duration = 100_u64;
     let booking_id = {
         client.set_my_rate(&expert, &rate_per_second);
-        client.book_session(&user, &expert, &max_duration)
+        client.book_session(&user, &expert, &max_duration, &token.address)
     };
 
     let actual_duration = 0_u64;
@@ -283,7 +283,7 @@ fn test_book_session_balance_transfer() {
 
     let booking_id = {
         client.set_my_rate(&expert, &rate_per_second);
-        client.book_session(&user, &expert, &max_duration)
+        client.book_session(&user, &expert, &max_duration, &token.address)
     };
 
     assert_eq!(token.balance(&user), initial_balance - expected_deposit);
@@ -293,7 +293,7 @@ fn test_book_session_balance_transfer() {
     token.mint(&user, &expected_deposit);
     let booking_id_2 = {
         client.set_my_rate(&expert, &rate_per_second);
-        client.book_session(&user, &expert, &max_duration)
+        client.book_session(&user, &expert, &max_duration, &token.address)
     };
 
     assert_eq!(booking_id_2, 2);
@@ -323,11 +323,11 @@ fn test_get_user_and_expert_bookings() {
     let max_duration = 100_u64;
     let booking_id_1 = {
         client.set_my_rate(&expert1, &rate_per_second);
-        client.book_session(&user, &expert1, &max_duration)
+        client.book_session(&user, &expert1, &max_duration, &token.address)
     };
     let booking_id_2 = {
         client.set_my_rate(&expert2, &rate_per_second);
-        client.book_session(&user, &expert2, &max_duration)
+        client.book_session(&user, &expert2, &max_duration, &token.address)
     };
 
     // Paginated: fetch all 2 user bookings starting at index 0
@@ -386,7 +386,7 @@ fn test_reclaim_stale_session_too_early() {
     let max_duration = 100_u64;
     let booking_id = {
         client.set_my_rate(&expert, &rate_per_second);
-        client.book_session(&user, &expert, &max_duration)
+        client.book_session(&user, &expert, &max_duration, &token.address)
     };
 
     let result = client.try_reclaim_stale_session(&user, &booking_id);
@@ -418,7 +418,7 @@ fn test_reclaim_stale_session_success() {
     let max_duration = 100_u64;
     let booking_id = {
         client.set_my_rate(&expert, &rate_per_second);
-        client.book_session(&user, &expert, &max_duration)
+        client.book_session(&user, &expert, &max_duration, &token.address)
     };
 
     env.ledger()
@@ -455,7 +455,7 @@ fn test_reclaim_stale_session_wrong_user() {
     let max_duration = 100_u64;
     let booking_id = {
         client.set_my_rate(&expert, &rate_per_second);
-        client.book_session(&user, &expert, &max_duration)
+        client.book_session(&user, &expert, &max_duration, &token.address)
     };
 
     env.ledger()
@@ -489,7 +489,7 @@ fn test_reclaim_already_finalized() {
     let max_duration = 100_u64;
     let booking_id = {
         client.set_my_rate(&expert, &rate_per_second);
-        client.book_session(&user, &expert, &max_duration)
+        client.book_session(&user, &expert, &max_duration, &token.address)
     };
 
     client.finalize_session(&booking_id, &50);
@@ -523,7 +523,7 @@ fn test_expert_rejects_pending_session() {
     let max_duration = 100_u64;
     let booking_id = {
         client.set_my_rate(&expert, &rate_per_second);
-        client.book_session(&user, &expert, &max_duration)
+        client.book_session(&user, &expert, &max_duration, &token.address)
     };
 
     assert_eq!(token.balance(&user), 9_000);
@@ -563,7 +563,7 @@ fn test_user_cannot_reject_session() {
     let max_duration = 100_u64;
     let booking_id = {
         client.set_my_rate(&expert, &rate_per_second);
-        client.book_session(&user, &expert, &max_duration)
+        client.book_session(&user, &expert, &max_duration, &token.address)
     };
 
     let result = client.try_reject_session(&user, &booking_id);
@@ -594,7 +594,7 @@ fn test_reject_already_complete_session() {
     let max_duration = 100_u64;
     let booking_id = {
         client.set_my_rate(&expert, &rate_per_second);
-        client.book_session(&user, &expert, &max_duration)
+        client.book_session(&user, &expert, &max_duration, &token.address)
     };
 
     client.finalize_session(&booking_id, &50);
@@ -625,7 +625,7 @@ fn test_reject_already_reclaimed_session() {
     let max_duration = 100_u64;
     let booking_id = {
         client.set_my_rate(&expert, &rate_per_second);
-        client.book_session(&user, &expert, &max_duration)
+        client.book_session(&user, &expert, &max_duration, &token.address)
     };
 
     env.ledger()
@@ -659,7 +659,7 @@ fn test_wrong_expert_cannot_reject() {
     let max_duration = 100_u64;
     let booking_id = {
         client.set_my_rate(&expert, &rate_per_second);
-        client.book_session(&user, &expert, &max_duration)
+        client.book_session(&user, &expert, &max_duration, &token.address)
     };
 
     let result = client.try_reject_session(&wrong_expert, &booking_id);
@@ -773,7 +773,7 @@ fn test_set_oracle_success() {
 
     // Book a session
     client.set_my_rate(&expert, &10_i128);
-    let booking_id = client.book_session(&user, &expert, &100);
+    let booking_id = client.book_session(&user, &expert, &100, &token_contract.address);
 
     // Rotate oracle to new address
     let result = client.try_set_oracle(&oracle_new);
@@ -876,7 +876,7 @@ fn test_book_session_calculates_correct_deposit() {
     let max_duration = 100_u64;
     let expected_deposit = stored_rate * (max_duration as i128);
 
-    let _booking_id = client.book_session(&user, &expert, &max_duration);
+    let _booking_id = client.book_session(&user, &expert, &max_duration, &token.address);
 
     assert_eq!(token.balance(&user), initial_balance - expected_deposit);
     assert_eq!(token.balance(&client.address), expected_deposit);
@@ -901,7 +901,7 @@ fn test_book_session_fails_if_expert_rate_not_set() {
     client.init(&admin, &token.address, &oracle, &registry);
 
     let max_duration = 100_u64;
-    let res = client.try_book_session(&user, &expert, &max_duration);
+    let res = client.try_book_session(&user, &expert, &max_duration, &token.address);
 
     assert!(res.is_err());
 }
@@ -932,7 +932,7 @@ fn test_book_session_fails_if_expert_not_verified() {
 
     // Book session should fail with ExpertNotVerified error
     let max_duration = 100_u64;
-    let res = client.try_book_session(&user, &expert, &max_duration);
+    let res = client.try_book_session(&user, &expert, &max_duration, &token.address);
 
     assert!(res.is_err());
 }
@@ -962,7 +962,7 @@ fn test_pause_blocks_book_session() {
     let result = client.try_pause();
     assert!(result.is_ok());
 
-    let result = client.try_book_session(&user, &expert, &100);
+    let result = client.try_book_session(&user, &expert, &100, &token.address);
     assert!(result.is_err());
 
     assert_eq!(token.balance(&user), 10_000);
@@ -988,7 +988,7 @@ fn test_pause_blocks_finalize_session() {
 
     let booking_id = {
         client.set_my_rate(&expert, &10_i128);
-        client.book_session(&user, &expert, &100)
+        client.book_session(&user, &expert, &100, &token.address)
     };
 
     client.pause();
@@ -1017,7 +1017,7 @@ fn test_pause_blocks_reclaim_stale_session() {
 
     let booking_id = {
         client.set_my_rate(&expert, &10_i128);
-        client.book_session(&user, &expert, &100)
+        client.book_session(&user, &expert, &100, &token.address)
     };
 
     env.ledger()
@@ -1049,7 +1049,7 @@ fn test_pause_blocks_reject_session() {
 
     let booking_id = {
         client.set_my_rate(&expert, &10_i128);
-        client.book_session(&user, &expert, &100)
+        client.book_session(&user, &expert, &100, &token.address)
     };
 
     client.pause();
@@ -1079,13 +1079,13 @@ fn test_unpause_resumes_operations() {
     client.set_my_rate(&expert, &10_i128);
     client.pause();
 
-    let result = client.try_book_session(&user, &expert, &100);
+    let result = client.try_book_session(&user, &expert, &100, &token.address);
     assert!(result.is_err());
 
     let result = client.try_unpause();
     assert!(result.is_ok());
 
-    let booking_id = client.book_session(&user, &expert, &100);
+    let booking_id = client.book_session(&user, &expert, &100, &token.address);
     assert_eq!(booking_id, 1);
     assert_eq!(token.balance(&user), 9_000);
     assert_eq!(token.balance(&client.address), 1_000);
@@ -1111,7 +1111,7 @@ fn test_read_only_functions_work_while_paused() {
 
     let booking_id = {
         client.set_my_rate(&expert, &10_i128);
-        client.book_session(&user, &expert, &100)
+        client.book_session(&user, &expert, &100, &token.address)
     };
 
     client.pause();
@@ -1163,7 +1163,7 @@ fn test_scale_50_bookings_single_user_with_pagination() {
     // Book 50 sessions
     let mut booking_ids = std::vec::Vec::new();
     for _ in 0..50 {
-        let id = client.book_session(&user, &expert, &max_duration);
+        let id = client.book_session(&user, &expert, &max_duration, &token.address);
         booking_ids.push(id);
     }
 
@@ -1224,8 +1224,8 @@ fn test_pagination_isolation_between_users() {
 
     // 25 bookings for user_a then 25 for user_b (interleaved global booking IDs)
     for _ in 0..25 {
-        client.book_session(&user_a, &expert, &1);
-        client.book_session(&user_b, &expert, &1);
+        client.book_session(&user_a, &expert, &1, &token.address);
+        client.book_session(&user_b, &expert, &1, &token.address);
     }
 
     assert_eq!(client.get_user_booking_count(&user_a), 25);
@@ -1272,7 +1272,7 @@ fn test_user_cancels_before_session_starts_success() {
 
     let booking_id = {
         client.set_my_rate(&expert, &10_i128);
-        client.book_session(&user, &expert, &100)
+        client.book_session(&user, &expert, &100, &token.address)
     };
 
     assert_eq!(token.balance(&user), 9_000);
@@ -1311,7 +1311,7 @@ fn test_user_cannot_cancel_after_oracle_marks_started() {
 
     let booking_id = {
         client.set_my_rate(&expert, &10_i128);
-        client.book_session(&user, &expert, &100)
+        client.book_session(&user, &expert, &100, &token.address)
     };
 
     // Oracle marks session as started
@@ -1356,7 +1356,7 @@ fn test_booking_with_18_decimal_token_scale_no_overflow() {
     client.init(&admin, &token.address, &oracle, &registry);
 
     client.set_my_rate(&expert, &rate_per_second);
-    let booking_id = client.book_session(&user, &expert, &max_duration);
+    let booking_id = client.book_session(&user, &expert, &max_duration, &token.address);
 
     assert_eq!(token.balance(&user), 0);
     assert_eq!(token.balance(&client.address), expected_deposit);
@@ -1393,7 +1393,7 @@ fn test_expert_pagination_50_bookings() {
     for _ in 0..50 {
         let user = Address::generate(&env);
         token.mint(&user, &1);
-        client.book_session(&user, &expert, &1);
+        client.book_session(&user, &expert, &1, &token.address);
     }
 
     assert_eq!(client.get_expert_booking_count(&expert), 50);
@@ -1429,7 +1429,7 @@ fn test_top_up_session_success() {
 
     let booking_id = {
         client.set_my_rate(&expert, &rate_per_second);
-        client.book_session(&user, &expert, &initial_duration)
+        client.book_session(&user, &expert, &initial_duration, &token.address)
     };
 
     let initial_deposit = rate_per_second * (initial_duration as i128); // 18,000
@@ -1475,7 +1475,7 @@ fn test_top_up_wrong_user_fails() {
 
     let booking_id = {
         client.set_my_rate(&expert, &rate_per_second);
-        client.book_session(&user, &expert, &initial_duration)
+        client.book_session(&user, &expert, &initial_duration, &token.address)
     };
 
     let result = client.try_top_up_session(&other_user, &booking_id, &900);
@@ -1504,7 +1504,7 @@ fn test_resolve_dispute_admin_splits_funds() {
 
     let booking_id = {
         client.set_my_rate(&expert, &10_i128);
-        client.book_session(&user, &expert, &100)
+        client.book_session(&user, &expert, &100, &token.address)
     };
 
     // Deposit is 1000. Split: 600 to user, 400 to expert.
@@ -1538,7 +1538,7 @@ fn test_resolve_dispute_only_admin_can_call() {
 
     let booking_id = {
         client.set_my_rate(&expert, &10_i128);
-        client.book_session(&user, &expert, &100)
+        client.book_session(&user, &expert, &100, &token.address)
     };
 
     // Clear all mocked auths — now calls requiring auth will fail
@@ -1569,7 +1569,7 @@ fn test_resolve_dispute_split_exceeds_deposit_panics() {
 
     let booking_id = {
         client.set_my_rate(&expert, &10_i128);
-        client.book_session(&user, &expert, &100)
+        client.book_session(&user, &expert, &100, &token.address)
     };
 
     // Deposit is 1000. Split of 600 + 500 = 1100 exceeds deposit.
@@ -1596,7 +1596,7 @@ fn test_resolve_dispute_split_exceeds_deposit_returns_error() {
 
     let booking_id = {
         client.set_my_rate(&expert, &10_i128);
-        client.book_session(&user, &expert, &100)
+        client.book_session(&user, &expert, &100, &token.address)
     };
 
     // Deposit is 1000. Split of 600 + 500 = 1100 exceeds deposit.
@@ -1628,7 +1628,7 @@ fn test_resolve_dispute_negative_split_amounts_return_error() {
 
     let booking_id = {
         client.set_my_rate(&expert, &10_i128);
-        client.book_session(&user, &expert, &100)
+        client.book_session(&user, &expert, &100, &token.address)
     };
 
     let negative_user_refund = client.try_resolve_dispute(&booking_id, &-1, &500);
@@ -1665,7 +1665,7 @@ fn test_resolve_dispute_only_pending_bookings() {
 
     let booking_id = {
         client.set_my_rate(&expert, &10_i128);
-        client.book_session(&user, &expert, &100)
+        client.book_session(&user, &expert, &100, &token.address)
     };
 
     // Finalize first — booking is now Complete
@@ -1696,7 +1696,7 @@ fn test_resolve_dispute_partial_split_leaves_remainder_in_vault() {
 
     let booking_id = {
         client.set_my_rate(&expert, &10_i128);
-        client.book_session(&user, &expert, &100)
+        client.book_session(&user, &expert, &100, &token.address)
     };
 
     // Deposit is 1000. Split only 300 + 200 = 500. Remaining 500 stays in vault
@@ -1728,7 +1728,7 @@ fn test_admin_can_recover_disputed_remainder_once() {
 
     let booking_id = {
         client.set_my_rate(&expert, &10_i128);
-        client.book_session(&user, &expert, &100)
+        client.book_session(&user, &expert, &100, &token.address)
     };
 
     // Deposit is 1000; 500 is intentionally left to recover.
@@ -1768,7 +1768,7 @@ fn test_non_admin_cannot_recover_disputed_remainder() {
 
     let booking_id = {
         client.set_my_rate(&expert, &10_i128);
-        client.book_session(&user, &expert, &100)
+        client.book_session(&user, &expert, &100, &token.address)
     };
 
     client.resolve_dispute(&booking_id, &300, &200);
@@ -1802,7 +1802,7 @@ fn test_recover_disputed_remainder_requires_disputed_status() {
 
     let booking_id = {
         client.set_my_rate(&expert, &10_i128);
-        client.book_session(&user, &expert, &100)
+        client.book_session(&user, &expert, &100, &token.address)
     };
 
     // Booking is still pending, so recovery must fail.
@@ -1830,7 +1830,7 @@ fn test_resolve_dispute_blocked_when_paused() {
 
     let booking_id = {
         client.set_my_rate(&expert, &10_i128);
-        client.book_session(&user, &expert, &100)
+        client.book_session(&user, &expert, &100, &token.address)
     };
 
     client.pause();
@@ -1938,4 +1938,137 @@ fn test_upgrade_blocked_when_paused() {
     // add the paused check to upgrade_contract and flip this assertion.
     let result = client.try_upgrade_contract(&new_wasm_hash);
     assert!(result.is_ok());
+}
+
+// ==================== Multi-Token Tests ====================
+
+/// Admin adds a second token (USDC mock). User books with that token — should succeed.
+#[test]
+fn test_admin_adds_token_user_books_with_it() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let expert = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let registry = create_mock_registry(&env);
+
+    // Primary token (XLM-like) — registered via init
+    let xlm_admin = Address::generate(&env);
+    let xlm = create_token_contract(&env, &xlm_admin);
+
+    // Secondary token (USDC-like) — registered via add_payment_token
+    let usdc_admin = Address::generate(&env);
+    let usdc = create_token_contract(&env, &usdc_admin);
+
+    // Mint USDC to user only — they pay with USDC
+    usdc.mint(&user, &10_000);
+
+    let client = create_client(&env);
+    client.init(&admin, &xlm.address, &oracle, &registry);
+
+    // Admin whitelists USDC
+    let res = client.try_add_payment_token(&usdc.address);
+    assert!(res.is_ok());
+
+    // Expert sets rate
+    client.set_my_rate(&expert, &10_i128);
+
+    // User books using USDC
+    let max_duration = 100_u64;
+    let booking_id = client.book_session(&user, &expert, &max_duration, &usdc.address);
+
+    // User's USDC was escrowed
+    assert_eq!(usdc.balance(&user), 9_000);
+    assert_eq!(usdc.balance(&client.address), 1_000);
+
+    // Booking records the correct token
+    let booking = client.get_booking(&booking_id).unwrap();
+    assert_eq!(booking.token_address, usdc.address);
+
+    // Finalize — payouts happen in USDC
+    client.finalize_session(&booking_id, &50);
+    assert_eq!(usdc.balance(&expert), 500);
+    assert_eq!(usdc.balance(&user), 9_500);
+    assert_eq!(usdc.balance(&client.address), 0);
+}
+
+/// User tries to book with a token that was never whitelisted — should fail with TokenNotAllowed.
+#[test]
+fn test_book_with_unregistered_token_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let expert = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let registry = create_mock_registry(&env);
+
+    let xlm_admin = Address::generate(&env);
+    let xlm = create_token_contract(&env, &xlm_admin);
+
+    // A fake token that is never whitelisted
+    let fake_admin = Address::generate(&env);
+    let fake_token = create_token_contract(&env, &fake_admin);
+    fake_token.mint(&user, &10_000);
+
+    let client = create_client(&env);
+    client.init(&admin, &xlm.address, &oracle, &registry);
+
+    // Expert sets rate
+    client.set_my_rate(&expert, &10_i128);
+
+    // Booking with unregistered token must fail
+    let res = client.try_book_session(&user, &expert, &100, &fake_token.address);
+    assert!(res.is_err());
+
+    // No funds should have moved
+    assert_eq!(fake_token.balance(&user), 10_000);
+    assert_eq!(fake_token.balance(&client.address), 0);
+}
+
+/// Admin removes a whitelisted token; subsequent bookings with it must fail,
+/// while existing bookings (already escrowed) still settle correctly.
+#[test]
+fn test_remove_payment_token_blocks_new_bookings_but_not_existing() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let expert = Address::generate(&env);
+    let oracle = Address::generate(&env);
+    let registry = create_mock_registry(&env);
+
+    let usdc_admin = Address::generate(&env);
+    let usdc = create_token_contract(&env, &usdc_admin);
+    usdc.mint(&user, &20_000);
+
+    let xlm_admin = Address::generate(&env);
+    let xlm = create_token_contract(&env, &xlm_admin);
+
+    let client = create_client(&env);
+    client.init(&admin, &xlm.address, &oracle, &registry);
+
+    // Whitelist USDC and book a session
+    client.add_payment_token(&usdc.address);
+    client.set_my_rate(&expert, &10_i128);
+    let booking_id = client.book_session(&user, &expert, &100, &usdc.address);
+    assert_eq!(usdc.balance(&client.address), 1_000);
+
+    // Admin removes USDC from the allowlist
+    let res = client.try_remove_payment_token(&usdc.address);
+    assert!(res.is_ok());
+
+    // New booking with USDC must now fail
+    let new_res = client.try_book_session(&user, &expert, &100, &usdc.address);
+    assert!(new_res.is_err());
+
+    // But the existing booking finalizes correctly — token stored on booking record
+    client.finalize_session(&booking_id, &50);
+    assert_eq!(usdc.balance(&expert), 500);
+    assert_eq!(usdc.balance(&user), 19_500);
+    assert_eq!(usdc.balance(&client.address), 0);
 }

--- a/contracts/payment-vault-contract/src/types.rs
+++ b/contracts/payment-vault-contract/src/types.rs
@@ -20,6 +20,7 @@ pub struct BookingRecord {
     pub id: u64,                           // Storage key identifier
     pub user: Address,                     // User who created the booking
     pub expert: Address,                   // Expert providing consultation
+    pub token_address: Address,            // Payment token used for this booking
     pub rate_per_second: i128, // Payment rate per second in atomic units of the payment token
     pub max_duration: u64,     // Maximum booked duration in seconds
     pub total_deposit: i128,   // Total deposit (rate_per_second * max_duration)


### PR DESCRIPTION
## Summary

Closes #37

Implements multi-token support for the `payment-vault-contract`, allowing the platform to accept XLM, USDC, and any other whitelisted stablecoin simultaneously — replacing the previous single-token-at-init design.

---

## Changes

### `src/storage.rs`
- Removed `DataKey::Token` (global singleton key)
- Added `DataKey::AllowedToken(Address)` — a per-token boolean flag stored in instance storage
- Added helpers: `add_allowed_token`, `remove_allowed_token`, `is_token_allowed`
- The token passed to `init()` is automatically seeded into the allowlist, preserving backwards-compatible behaviour

### `src/types.rs`
- Added `token_address: Address` field to `BookingRecord`
- The payment token is recorded at booking-time, allowing each booking to settle in its own token regardless of future allowlist changes

### `src/error.rs`
- Added `TokenNotAllowed = 15` error variant, returned when `book_session` is called with a non-whitelisted token

### `src/contract.rs`
- `initialize_vault`: seeds the first allowed token via `add_allowed_token` instead of a global `set_token`
- New: `add_payment_token(env, token)` — admin-auth, whitelists a new payment token
- New: `remove_payment_token(env, token)` — admin-auth, removes a token from the allowlist (existing bookings unaffected)
- `book_session`: accepts new `payment_token: Address` parameter; validates allowlist membership before escrowing; stores `token_address` on `BookingRecord`
- All settlement paths (`finalize_session`, `top_up_session`, `reclaim_stale_session`, `cancel_booking`, `reject_session`, `resolve_dispute`, `recover_disputed_remainder`) now resolve the token from `booking.token_address` instead of a global lookup

### `src/lib.rs`
- Exposed `add_payment_token` and `remove_payment_token` in `#[contractimpl]`
- Updated `book_session` public signature to include `payment_token: Address`

### `src/test.rs`
- Updated all existing `book_session` call sites with the new `payment_token` argument
- **New test:** `test_admin_adds_token_user_books_with_it` — admin whitelists USDC; user books and finalises in USDC ✅
- **New test:** `test_book_with_unregistered_token_fails` — booking with a non-whitelisted fake token is rejected ✅
- **New test:** `test_remove_payment_token_blocks_new_bookings_but_not_existing` — removing a token blocks new bookings while existing escrowed bookings still settle correctly ✅

---

## Test Results

```
running 61 tests
... 59 passed; 0 failed; 2 ignored
```

All 59 active tests pass. The 2 ignored tests are pre-existing upgrade tests blocked by Soroban SDK issue #1089.

---

## Acceptance Criteria

| Requirement | Status |
|---|---|
| `DataKey::Token` replaced with `DataKey::AllowedToken(Address)` | ✅ |
| `add_allowed_token` / `remove_allowed_token` helpers in storage | ✅ |
| `token_address: Address` added to `BookingRecord` | ✅ |
| `add_payment_token(env, token)` with admin auth | ✅ |
| `book_session` accepts `payment_token: Address` | ✅ |
| `is_token_allowed` verified in `book_session` | ✅ |
| Admin adds USDC → user books with USDC → success | ✅ |
| User books with unregistered token → fails | ✅ |
| Users can book sessions using different whitelisted assets | ✅ |