### PR TITLE
feat(identity-registry): allow admin transfer

### DIFF
--- a/contracts/identity-registry-contract/src/contract.rs
+++ b/contracts/identity-registry-contract/src/contract.rs
@@ -14,6 +14,17 @@ pub fn initialize_registry(env: &Env, admin: &Address) -> Result<(), RegistryErr
     Ok(())
 }
 
+/// Transfer admin rights to a new address (Admin only)
+pub fn transfer_admin(env: &Env, new_admin: &Address) -> Result<(), RegistryError> {
+    let current_admin = storage::get_admin(env).ok_or(RegistryError::NotInitialized)?;
+    current_admin.require_auth();
+
+    storage::set_admin(env, new_admin);
+    events::emit_admin_transferred(env, current_admin, new_admin.clone());
+
+    Ok(())
+}
+
 /// Verify an expert by setting their status to Verified (Admin only)
 /// Batch Verification
 pub fn batch_add_experts(env: Env, experts: Vec<Address>) -> Result<(), RegistryError> {

--- a/contracts/identity-registry-contract/src/events.rs
+++ b/contracts/identity-registry-contract/src/events.rs
@@ -46,3 +46,19 @@ pub fn emit_profile_updated(env: &Env, expert: Address, new_uri: String) {
     env.events()
         .publish((Symbol::new(env, "profile_updated"),), event);
 }
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferredEvent {
+    pub previous_admin: Address,
+    pub new_admin: Address,
+}
+
+pub fn emit_admin_transferred(env: &Env, previous_admin: Address, new_admin: Address) {
+    let event = AdminTransferredEvent {
+        previous_admin,
+        new_admin,
+    };
+    env.events()
+        .publish((Symbol::new(env, "admin_transferred"),), event);
+}

--- a/contracts/identity-registry-contract/src/lib.rs
+++ b/contracts/identity-registry-contract/src/lib.rs
@@ -22,6 +22,11 @@ impl IdentityRegistryContract {
         contract::initialize_registry(&env, &admin)
     }
 
+    /// Transfer admin rights to a new address (Admin only)
+    pub fn transfer_admin(env: Env, new_admin: Address) -> Result<(), RegistryError> {
+        contract::transfer_admin(&env, &new_admin)
+    }
+
     /// Add a moderator (Admin only)
     pub fn add_moderator(env: Env, moderator: Address) -> Result<(), RegistryError> {
         contract::add_moderator(&env, &moderator)

--- a/contracts/identity-registry-contract/src/test.rs
+++ b/contracts/identity-registry-contract/src/test.rs
@@ -29,6 +29,70 @@ fn test_initialization() {
 }
 
 #[test]
+fn test_transfer_admin_revokes_previous_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(IdentityRegistryContract, ());
+    let client = IdentityRegistryContractClient::new(&env, &contract_id);
+
+    let admin_a = Address::generate(&env);
+    let admin_b = Address::generate(&env);
+    let expert = Address::generate(&env);
+    let data_uri = String::from_str(&env, "ipfs://transferred-admin");
+
+    client.init(&admin_a);
+    client.transfer_admin(&admin_b);
+
+    let old_admin_result = client.try_add_expert(&admin_a, &expert, &data_uri, &0u32);
+    assert_eq!(old_admin_result, Err(Ok(RegistryError::Unauthorized)));
+
+    client.add_expert(&admin_b, &expert, &data_uri, &0u32);
+    assert_eq!(client.get_status(&expert), ExpertStatus::Verified);
+}
+
+#[test]
+#[should_panic]
+fn test_transfer_admin_requires_current_admin() {
+    let env = Env::default();
+
+    let contract_id = env.register(IdentityRegistryContract, ());
+    let client = IdentityRegistryContractClient::new(&env, &contract_id);
+
+    let admin_a = Address::generate(&env);
+    let admin_b = Address::generate(&env);
+
+    client.init(&admin_a);
+    client.transfer_admin(&admin_b);
+}
+
+#[test]
+fn test_transfer_admin_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(IdentityRegistryContract, ());
+    let client = IdentityRegistryContractClient::new(&env, &contract_id);
+
+    let admin_a = Address::generate(&env);
+    let admin_b = Address::generate(&env);
+
+    client.init(&admin_a);
+    client.transfer_admin(&admin_b);
+
+    let events = env.events().all();
+    let event = events.last().unwrap();
+    let topic: Symbol = event.1.get(0).unwrap().try_into_val(&env).unwrap();
+    assert_eq!(topic, Symbol::new(&env, "admin_transferred"));
+    let transferred: crate::events::AdminTransferredEvent = event.2
+        .clone()
+        .try_into_val(&env)
+        .unwrap();
+    assert_eq!(transferred.previous_admin, admin_a);
+    assert_eq!(transferred.new_admin, admin_b);
+}
+
+#[test]
 fn test_data_uri_persisted_on_verify() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
# 🧠 SkillSphere Pull Request 

- [ ] Closes # (Insert Issue Number)
- [x] Added tests
- [ ] Ran `cargo test` (Cargo is unavailable in the container)
- [ ] Evidence attached
- [x] Commented the code

---

### 📌 Type of Change

- [ ] 📚 Documentation
- [ ] 🐛 Bug fix
- [x] ✨ Enhancement
- [ ] 💥 Breaking change
- [ ] 🏗️ Refactor

---

## 📝 Changes Description

Implemented secure SuperAdmin transfer for the Identity Registry contract.

### Changes

- Added the public `transfer_admin(env, new_admin)` contract entrypoint.
- Required authorization from the currently stored admin.
- Overwrote `DataKey::Admin` with the new wallet or DAO multisig address.
- Added the `admin_transferred` event containing:
  - `previous_admin`
  - `new_admin`
- Added tests confirming:
  - The previous admin loses admin privileges after transfer.
  - The new admin can verify experts.
  - Transfer requires current-admin authorization.
  - The transfer event topic and payload are emitted correctly.

### Storage and Gas Impact

The existing instance storage key, `DataKey::Admin`, is overwritten in place. No migration or new persistent storage structure is required. The transfer adds one instance storage write and one event emission.

## 🌌 Comments

Admin rights are transferred atomically only after the current admin passes authorization. Once the transfer succeeds, the previous admin can no longer perform admin-only operations.

The implementation is available on branch:

`feature/identity-registry-transfer-admin`

Commit:

`cb82c17`

## Related Issue

Closes #39 